### PR TITLE
fix build

### DIFF
--- a/src/mrb_linenoise.c
+++ b/src/mrb_linenoise.c
@@ -7,6 +7,7 @@
 #include <mruby/error.h>
 #include <string.h>
 #include <mruby/throw.h>
+#include <mruby/class.h>
 #include <stdlib.h>
 #include "linenoise.h"
 


### PR DESCRIPTION
add include declaration because prototype declaration of mrb_define_alias() has moved from include/mruby.h to include/mruby/class.h in new byte code VM.